### PR TITLE
Setup flake8-docstrings plugin.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
      flake8
      flake8-bugbear
      flake8-builtins
+     flake8-docstrings
      flake8-pyi
      flake8-pytest
      flake8-pytest-style


### PR DESCRIPTION
A possible workaround for https://github.com/PyCQA/pydocstyle/issues/414 could be similar settings in the `setup.cfg`: 

```ini
# Disable some pydocstyle checks:
# Exclude some pydoctest checks globally:
ignore = D100, D104, D106, D401, W504, X100, RST303, RST304
```
