### PR TITLE
Deny to use the same step twice in the story.

### DIFF
--- a/src/_stories/collect.py
+++ b/src/_stories/collect.py
@@ -11,6 +11,8 @@ def collect_story(f):
 
     class Collector(object):
         def __getattr__(self, name):
+            if name in calls:
+                raise StoryDefinitionError("Story has repeated steps: " + name)
             calls.append(name)
 
     f(Collector())

--- a/tests/test_story.py
+++ b/tests/test_story.py
@@ -32,6 +32,21 @@ def test_deny_empty_stories():
     assert str(exc_info.value) == "Story should have at least one step defined"
 
 
+def test_deny_repeat_steps():
+    """We can not define a story which has duplicating steps."""
+
+    with pytest.raises(StoryDefinitionError) as exc_info:
+
+        class Action(object):
+            @story
+            def do(I):
+                I.foo
+                I.bar
+                I.foo
+
+    assert str(exc_info.value) == "Story has repeated steps: foo"
+
+
 def test_story_representation(x):
 
     story = repr(x.Simple().x)


### PR DESCRIPTION
Things let to do in this pull request:
- [ ] test composition without inheritance
- [ ] test injection of the same substory twice into different arguments of the parent story
- [ ] test usage of the same method with different name when the same method stored as class attribute
- [ ] fix found failures in existing tests 